### PR TITLE
Update to check whether an element was hidden

### DIFF
--- a/screentime.js
+++ b/screentime.js
@@ -126,6 +126,11 @@
     function onScreen(viewport, field) {
       var cond, buffered, partialView;
 
+      // Field not hidden by design
+      if($(field.selector).is(':hidden') ){
+        return false;
+      }
+      
       // Field entirely within viewport
       if ((field.bottom <= viewport.bottom) && (field.top >= viewport.top)) {
         return true;
@@ -154,7 +159,7 @@
       var viewport = new Viewport();
 
       $.each(cache, function(key, val) {
-        if ( (onScreen(viewport, val)) && ($(val.selector).is(':visible')) ) {
+        if (onScreen(viewport, val)) {
           log[key] += 1;
           counter[key] += 1;
         }

--- a/screentime.js
+++ b/screentime.js
@@ -154,7 +154,7 @@
       var viewport = new Viewport();
 
       $.each(cache, function(key, val) {
-        if (onScreen(viewport, val)) {
+        if ( (onScreen(viewport, val)) && ($(val.selector).is(':visible')) ) {
           log[key] += 1;
           counter[key] += 1;
         }


### PR DESCRIPTION
Changed line 157 to check (again?) whether an element is hidden by another script. For me, all elements were timed, even though some where hidden by jQuery in the runtime (display:none, yet still technically on screen). I don't know if visibly.js does check this (only once), or where exactly this check failed, but this fixed it. 
Thanks for the script!